### PR TITLE
Problem with multiple result sets

### DIFF
--- a/src/result.cc
+++ b/src/result.cc
@@ -77,6 +77,15 @@ node_db_mysql::Result::Result(MYSQL* connection) throw(node_db::Exception&)
     nextRow(NULL) {
     this->result = mysql_store_result(this->connection);
 
+    MYSQL_RES *result;
+    /* check if there are more resultsets */
+    while(mysql_more_results(this->connection)) {
+        if (mysql_next_result(this->connection)<=0) {
+	    result = mysql_store_result(this->connection);
+	    mysql_free_result(result);
+	}
+    }
+
     try {
         if (result == NULL && mysql_field_count(this->connection) != 0) {
             throw node_db::Exception(mysql_error(this->connection));


### PR DESCRIPTION
The current release appears to be unable to handle queries returning multiple result sets.
A simple stored procedure call can therefore apparently result in all further queries triggering the error "Commands out of sync; you can't run this command now" because not all result sets are processed.

I've added a simple "workaround" to the Results class, that discards all additional sets, so that at least the first one can be used, and the connection remains error free.
